### PR TITLE
Make TimePeriod copy/clone and FeedOption clone

### DIFF
--- a/src/util/option.rs
+++ b/src/util/option.rs
@@ -6,6 +6,7 @@
 //! through the listing.
 
 /// Basic feed options
+#[derive(Clone, Debug)]
 pub struct FeedOption {
     /// `after` and `before` indicate the fullname of an item in the listing to use as the anchor point of the slice.
     pub after: Option<String>,
@@ -62,6 +63,7 @@ impl FeedOption {
 }
 
 /// Allows you to request a certain time period. This only works in certain situations, like when asking for top of a subreddit
+#[derive(Copy, Clone, Debug)]
 pub enum TimePeriod {
     /// Posts from very recently
     Now,


### PR DESCRIPTION
While working with this library I ran into a small issue where I could not easily copy/clone the TimePeriod struct, even though I think this have been possible. So in this PR I added a few derives for TimePeriod and FeedOption.

I think more structs in the API should implement Clone and if appropriate Copy too. Since I am not that familiar with the API, I decided to keep it simple for now, but I do think this would be a good ergonomic improvement. 