### PR TITLE
Added selftext to user submitted

### DIFF
--- a/src/user/responses/submitted.rs
+++ b/src/user/responses/submitted.rs
@@ -9,6 +9,8 @@ pub struct SubmittedData {
     pub subreddit: String,
     /// Title
     pub title: String,
+    /// Selftext
+    pub selftext: String,
     /// Thumbnail
     pub thumbnail: String,
     /// Score


### PR DESCRIPTION
There are only a small sampling of the fields returned from the submitted query currently parsed by serde.
The selftext (body text of the post), would be a useful field to include.