### PR TITLE
About endpoint

### DIFF
--- a/src/me/mod.rs
+++ b/src/me/mod.rs
@@ -8,7 +8,7 @@ use reqwest::{header, Client, Response};
 use serde::Serialize;
 
 use crate::config::Config;
-use crate::util::{url, RouxError, FeedOption};
+use crate::util::{url, FeedOption, RouxError};
 
 pub mod responses;
 

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -31,7 +31,7 @@ use reqwest::Client;
 
 pub mod responses;
 use crate::subreddit::responses::{Submissions, SubredditComments};
-use responses::Overview;
+use responses::{Overview, About};
 
 /// User.
 pub struct User {
@@ -102,6 +102,26 @@ impl User {
             .json::<SubredditComments>()
             .await?)
     }
+
+    /// Get user's about page
+    pub async fn about(
+        &self,
+        options: Option<FeedOption>,
+    ) -> Result<About, RouxError> {
+        let url = &mut format!("https://www.reddit.com/user/{}/about/.json", self.user);
+
+        if let Some(options) = options {
+            options.build_url(url);
+        }
+
+        Ok(self
+            .client
+            .get(&url.to_owned())
+            .send()
+            .await?
+            .json::<About>()
+            .await?)
+    }
 }
 
 #[cfg(test)]
@@ -125,6 +145,10 @@ mod tests {
         // Test comments
         let comments = user.comments(None).await;
         assert!(comments.is_ok());
+
+        // Test about
+        let about = user.about(None).await;
+        assert!(about.is_ok());
 
         // Test feed options
         let after = comments.unwrap().data.after.unwrap();

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -109,11 +109,10 @@ impl User {
         options: Option<FeedOption>,
     ) -> Result<About, RouxError> {
         let url = &mut format!("https://www.reddit.com/user/{}/about/.json", self.user);
-
+        println!("{}",self.user);
         if let Some(options) = options {
             options.build_url(url);
         }
-
         Ok(self
             .client
             .get(&url.to_owned())

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -31,7 +31,7 @@ use reqwest::Client;
 
 pub mod responses;
 use crate::subreddit::responses::{Submissions, SubredditComments};
-use responses::{Overview, About};
+use responses::{About, Overview};
 
 /// User.
 pub struct User {
@@ -104,12 +104,9 @@ impl User {
     }
 
     /// Get user's about page
-    pub async fn about(
-        &self,
-        options: Option<FeedOption>,
-    ) -> Result<About, RouxError> {
+    pub async fn about(&self, options: Option<FeedOption>) -> Result<About, RouxError> {
         let url = &mut format!("https://www.reddit.com/user/{}/about/.json", self.user);
-        println!("{}",self.user);
+        println!("{}", self.user);
         if let Some(options) = options {
             options.build_url(url);
         }

--- a/src/user/responses/about.rs
+++ b/src/user/responses/about.rs
@@ -1,21 +1,135 @@
 //! # User Overview Responses
-use crate::{responses::BasicThing};
+use crate::responses::BasicThing;
+use crate::subreddit::responses::SubredditData;
 use serde::Deserialize;
-
-/// SubredditData
-#[derive(Debug, Deserialize)]
-pub struct SubredditData {
-}
-
 
 /// AboutData
 #[derive(Debug, Deserialize)]
 pub struct AboutData {
-    ///snoovatar_img
-    pub snoovatar_img: String,
-
-    ///icon_img
-    pub icon_img: String
+    /// Is employee
+    pub is_employee: Option<bool>,
+    /// has visited new profile
+    pub has_visited_new_profile: Option<bool>,
+    /// is friend
+    pub is_friend: Option<bool>,
+    /// pref no profanity
+    pub pref_no_profanity: Option<bool>,
+    /// has external account
+    pub has_external_account: Option<bool>,
+    /// pref geopopoular
+    pub pref_geopopular: Option<String>,
+    /// pref show trending
+    pub pref_show_trending: Option<bool>,
+    /// subreddit 
+    ///pub subreddit: Option<SubredditData>,
+    /// pref show presence
+    pub pref_show_presence: Option<bool>,
+    /// snoovatar img
+    pub snoovatar_img: Option<String>,
+    /// snoovatar size. Array of size 2
+    pub snoovatar_size: Option<[u64; 2]>,
+    /// gold expiration
+    pub gold_expiration: Option<String>,
+    /// has gold subscription
+    pub has_gold_subscription: Option<bool>,
+    /// is sponsor
+    pub is_sponsor: Option<bool>,
+    /// num friends
+    pub num_friends: Option<i32>,
+    /// can edit name
+    pub can_edit_name: Option<bool>,
+    /// is blocked
+    pub is_blocked: Option<bool>,
+    /// verified
+    pub verified: Option<bool>,
+    /// new modmail exists
+    pub new_modmail_exists: Option<bool>,
+    /// pref autoplay
+    pub pref_autoplay: Option<bool>,
+    /// coints
+    pub coins: Option<i32>,
+    /// has paypal subscription
+    pub has_paypal_subscription: Option<bool>,
+    /// has subscribed to premium
+    pub has_subscribed_to_premium: Option<bool>,
+    /// id
+    pub id: Option<String>,
+    /// can create subreddit
+    pub can_create_subreddit: Option<bool>,
+    /// over 18
+    pub over_18: Option<bool>,
+    /// is gold
+    pub is_gold: Option<bool>,
+    /// is mod
+    pub is_mod: Option<bool>,
+    /// awarded karma
+    pub awarder_karma: Option<i32>,
+    /// suspension expiration utc
+    pub suspension_expiration_utc: Option<i64>,
+    /// has stripe subscription
+    pub has_stripe_subscription: Option<bool>,
+    /// is suspended
+    pub is_suspended: Option<bool>,
+    /// pref video autopaly
+    pub pref_video_autoplay: Option<bool>,
+    /// has android subscription
+    pub has_android_subscription: Option<bool>,
+    /// in redesign beta
+    pub in_redesign_beta: Option<bool>,
+    /// icon img
+    pub icon_img: Option<String>,
+    /// has mod mail
+    pub has_mod_mail: Option<bool>,
+    /// pref nightmode
+    pub pref_nightmode: Option<bool>,
+    /// awardee karma
+    pub awardee_karma:Option<i32>,
+    /// hide from robots
+    pub hide_from_robots: Option<bool>,
+    /// password set
+    pub password_set: Option<bool>,
+    /// modhash
+    pub modhash: Option<String>,
+    /// link karma
+    pub link_karma: Option<i32>,
+    /// force password reset
+    pub force_password_reset: Option<bool>,
+    /// total karma
+    pub total_karma: Option<i32>,
+    /// inbox count
+    pub inbox_count: Option<i32>,
+    /// pref top karma subreddits
+    pub pref_top_karma_subreddits: Option<bool>,
+    /// has mail
+    pub has_mail: Option<bool>,
+    /// pref show snoovatar
+    pub pref_show_snoovatar: Option<bool>,
+    /// name
+    pub name: Option<String>,
+    /// pref clickgadget
+    pub pref_clickgadget: Option<i32>,
+    /// created
+    pub created: Option<f64>,
+    /// has verified email
+    pub has_verified_email: Option<bool>,
+    /// gold creddits
+    pub gold_creddits: Option<i32>,
+    /// created utc
+    pub created_utc: Option<f64>,
+    /// has ios subscription
+    pub has_ios_subscription: Option<bool>,
+    /// pref show twitter
+    pub pref_show_twitter: Option<bool>,
+    /// in beta
+    pub in_beta: Option<bool>,
+    /// comment karma
+    pub comment_karma: Option<i32>,
+    /// accept followers
+    pub accept_followers: Option<bool>,
+    /// has subscribed
+    pub has_subscribed: Option<bool>,
+    /// accept pms
+    pub accept_pms: Option<bool>
 }
 
 /// Overview

--- a/src/user/responses/about.rs
+++ b/src/user/responses/about.rs
@@ -20,7 +20,7 @@ pub struct AboutData {
     pub pref_geopopular: Option<String>,
     /// pref show trending
     pub pref_show_trending: Option<bool>,
-    /// subreddit 
+    /// subreddit
     ///pub subreddit: Option<SubredditData>,
     /// pref show presence
     pub pref_show_presence: Option<bool>,
@@ -83,7 +83,7 @@ pub struct AboutData {
     /// pref nightmode
     pub pref_nightmode: Option<bool>,
     /// awardee karma
-    pub awardee_karma:Option<i32>,
+    pub awardee_karma: Option<i32>,
     /// hide from robots
     pub hide_from_robots: Option<bool>,
     /// password set
@@ -129,7 +129,7 @@ pub struct AboutData {
     /// has subscribed
     pub has_subscribed: Option<bool>,
     /// accept pms
-    pub accept_pms: Option<bool>
+    pub accept_pms: Option<bool>,
 }
 
 /// Overview

--- a/src/user/responses/about.rs
+++ b/src/user/responses/about.rs
@@ -1,0 +1,22 @@
+//! # User Overview Responses
+use crate::{responses::BasicThing};
+use serde::Deserialize;
+
+/// SubredditData
+#[derive(Debug, Deserialize)]
+pub struct SubredditData {
+}
+
+
+/// AboutData
+#[derive(Debug, Deserialize)]
+pub struct AboutData {
+    ///snoovatar_img
+    pub snoovatar_img: String,
+
+    ///icon_img
+    pub icon_img: String
+}
+
+/// Overview
+pub type About = BasicThing<AboutData>;

--- a/src/user/responses/mod.rs
+++ b/src/user/responses/mod.rs
@@ -1,3 +1,5 @@
 //! # User responses
 pub mod overview;
+pub mod about;
+pub use about::{About, AboutData};
 pub use overview::{Overview, OverviewData};

--- a/src/user/responses/mod.rs
+++ b/src/user/responses/mod.rs
@@ -1,5 +1,5 @@
 //! # User responses
-pub mod overview;
 pub mod about;
+pub mod overview;
 pub use about::{About, AboutData};
 pub use overview::{Overview, OverviewData};

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -8,9 +8,9 @@ extern crate tokio;
 mod tests {
     use std::env;
 
-    use roux::Reddit;
     use roux::me::responses::SavedData;
     use roux::util::FeedOption;
+    use roux::Reddit;
     use tokio;
 
     static USER_AGENT: &str = "macos:roux:v1.4.0 (by /u/beanpup_py)";
@@ -45,7 +45,10 @@ mod tests {
             SavedData::Submission(submissions_data) => &submissions_data.id,
         };
 
-        let saved2 = me.saved(Some(options.after(&saved1.data.after.unwrap()))).await.unwrap();
+        let saved2 = me
+            .saved(Some(options.after(&saved1.data.after.unwrap())))
+            .await
+            .unwrap();
         let last_child_id2 = match &saved2.data.children.last().unwrap().data {
             SavedData::Comment(comments_data) => comments_data.id.as_ref().unwrap(),
             SavedData::Submission(submissions_data) => &submissions_data.id,


### PR DESCRIPTION
Hey! Thanks for your work on this project. I've been using `roux` a little bit on a side project, and was missing a user specific endpoint, thus this PR.

Adds `/{user}/about` endpoint.

Example API call: `https://www.reddit.com/user/beneater/about/.json`

There's one wrinkle, `AboutData` has a `SubredditData` field which looks like just about the content of `SubredditData`, but `cargo test` fails if I add it back in. Currently it's commented out. 

 I'd not feel comfortable adding an _almost_ copy of `SubredditData`, unless you wish it be added as such