### PR TITLE
Remove '?' prefix in FeedOption::build_url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tags
 /target
 **/*.rs.bk
 .vscode
+.idea

--- a/src/models/me/mod.rs
+++ b/src/models/me/mod.rs
@@ -177,7 +177,7 @@ impl Me {
     #[maybe_async::maybe_async]
     pub async fn saved(&self, options: Option<FeedOption>) -> Result<Saved, RouxError> {
         let url = &mut format!(
-            "user/{}/saved/.json",
+            "user/{}/saved/.json?",
             self.config.username.to_owned().unwrap()
         );
 
@@ -192,7 +192,7 @@ impl Me {
     #[maybe_async::maybe_async]
     pub async fn upvoted(&self, options: Option<FeedOption>) -> Result<Saved, RouxError> {
         let url = &mut format!(
-            "user/{}/upvoted/.json",
+            "user/{}/upvoted/.json?",
             self.config.username.to_owned().unwrap()
         );
 
@@ -207,7 +207,7 @@ impl Me {
     #[maybe_async::maybe_async]
     pub async fn downvoted(&self, options: Option<FeedOption>) -> Result<Saved, RouxError> {
         let url = &mut format!(
-            "user/{}/downvoted/.json",
+            "user/{}/downvoted/.json?",
             self.config.username.to_owned().unwrap()
         );
 

--- a/src/models/user/mod.rs
+++ b/src/models/user/mod.rs
@@ -52,7 +52,7 @@ impl User {
     /// Get user's overview.
     #[maybe_async::maybe_async]
     pub async fn overview(&self, options: Option<FeedOption>) -> Result<Overview, RouxError> {
-        let url = &mut format!("https://www.reddit.com/user/{}/overview/.json", self.user);
+        let url = &mut format!("https://www.reddit.com/user/{}/overview/.json?", self.user);
 
         if let Some(options) = options {
             options.build_url(url);
@@ -70,7 +70,7 @@ impl User {
     /// Get user's submitted posts.
     #[maybe_async::maybe_async]
     pub async fn submitted(&self, options: Option<FeedOption>) -> Result<Submissions, RouxError> {
-        let url = &mut format!("https://www.reddit.com/user/{}/submitted/.json", self.user);
+        let url = &mut format!("https://www.reddit.com/user/{}/submitted/.json?", self.user);
 
         if let Some(options) = options {
             options.build_url(url);
@@ -88,7 +88,7 @@ impl User {
     /// Get user's submitted comments.
     #[maybe_async::maybe_async]
     pub async fn comments(&self, options: Option<FeedOption>) -> Result<Comments, RouxError> {
-        let url = &mut format!("https://www.reddit.com/user/{}/comments/.json", self.user);
+        let url = &mut format!("https://www.reddit.com/user/{}/comments/.json?", self.user);
 
         if let Some(options) = options {
             options.build_url(url);
@@ -106,7 +106,7 @@ impl User {
     /// Get user's about page
     #[maybe_async::maybe_async]
     pub async fn about(&self, options: Option<FeedOption>) -> Result<About, RouxError> {
-        let url = &mut format!("https://www.reddit.com/user/{}/about/.json", self.user);
+        let url = &mut format!("https://www.reddit.com/user/{}/about/.json?", self.user);
 
         if let Some(options) = options {
             options.build_url(url);

--- a/src/util/option.rs
+++ b/src/util/option.rs
@@ -72,9 +72,6 @@ impl FeedOption {
 
     /// Build a url from `FeedOption`
     pub fn build_url(self, url: &mut String) {
-        // Add a fake url attr so I don't have to parse things
-        url.push_str(&String::from("?"));
-
         if let Some(after) = self.after {
             url.push_str(&format!("&after={}", after));
         } else if let Some(before) = self.before {
@@ -150,7 +147,7 @@ mod tests {
         let url = &mut String::from("");
         options.build_url(url);
 
-        assert!(*url == format!("?&after={}&", after))
+        assert!(*url == format!("&after={}&", after))
     }
 
     #[test]
@@ -161,7 +158,7 @@ mod tests {
         let url = &mut String::from("");
         options.build_url(url);
 
-        assert!(*url == format!("?&before={}&", before))
+        assert!(*url == format!("&before={}&", before))
     }
 
     #[test]
@@ -172,6 +169,6 @@ mod tests {
         let url = &mut String::from("");
         options.build_url(url);
 
-        assert!(*url == format!("?&count={}&", count))
+        assert!(*url == format!("&count={}&", count))
     }
 }


### PR DESCRIPTION
Repeated inclusion of "?" to identify the query string will cause any parameters to which "?" is appended to be treated as "param?". This leads to the parameter being ignored by the Reddit API as it cannot be parsed correctly.
For example, when calling `Subreddit::new("ipad").latest(1, Some(FeedOption::new())`, the URL will be formatted as "https://www.reddit.com/r/Watchexchange/new.json?limit=1?", and `limit=1` is ignored.

For now, let's remove the "?" appending in `FeedOption::build_url` and instead include it in every URL passed to `build_url`.

Ultimately, we should probably rethink how we're specifying options. Current design, for example, allows limit to be specified twice in many places. The second limit specified in the URL will always be the one used (overriding the first).

Likewise, the splitting of options between `FeedOptions` and as function parameters makes for a confusing API. If `FeedOptions` are truly applicable everywhere, then we should remove redundant provisions of `limit`. If certain options (e.g., `before` and `after`) are only applicable in certain places, then perhaps we can forgo  `FeedOptions` and provide the appropriate parameters for each function corresponding to a REST API call.