### PR TITLE
feat: add application-only auth for read-only modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,34 +59,42 @@ let me = client.unwrap();
 me.submit_link("LINK_TITLE", "LINK", "SUBREDDIT").await?;
 ```
 
-### Read-Only Access Without A User
+### Read-Only Modules
 
-Reddit no longer serves its JSON endpoints to unauthenticated clients, so the read-only
-[Subreddit](https://docs.rs/roux/latest/roux/subreddit/index.html) and
-[User](https://docs.rs/roux/latest/roux/user/index.html) modules need a token too.
-If you don't set a username and password, an application-only token is requested with the
-`client_credentials` grant using just the client id and secret of your Reddit app.
+Reddit no longer serves its JSON endpoints to unauthenticated clients, so the read-only [Subreddit](https://docs.rs/roux/latest/roux/subreddit/index.html) and [User](https://docs.rs/roux/latest/roux/user/index.html) modules need a token too. If you don't set a username and password, an application-only token is requested using just the client id and secret of your Reddit app. `Subreddit::new`, `User::new` and `Subreddits::search` are deprecated and will most likely return a 403 from Reddit.
+
+#### Get Subreddit Posts
 
 ```rust
 use roux::Reddit;
-
 let subreddit = Reddit::new("USER_AGENT", "CLIENT_ID", "CLIENT_SECRET")
     .subreddit("rust")
-    .await?;
-let hot = subreddit.hot(25, None).await?;
+    .await
+    .unwrap();
 
+let hot = subreddit.hot(25, None).await?;
+```
+
+#### Get User Overview
+
+```rust
+use roux::Reddit;
 let user = Reddit::new("USER_AGENT", "CLIENT_ID", "CLIENT_SECRET")
     .user("spez")
-    .await?;
-let overview = user.overview(None).await?;
+    .await
+    .unwrap();
 
+let overview = user.overview(None).await?;
+```
+
+#### Search Subreddits
+
+```rust
+use roux::Reddit;
 let subreddits = Reddit::new("USER_AGENT", "CLIENT_ID", "CLIENT_SECRET")
     .search_subreddits("rust", Some(10), None)
     .await?;
 ```
-
-The unauthenticated constructors `Subreddit::new`, `User::new` and `Subreddits::search` are
-deprecated and will most likely return a 403 from Reddit.
 
 ## Blocking Client
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ let client = Reddit::new("USER_AGENT", "CLIENT_ID", "CLIENT_SECRET")
 
 let me = client.unwrap();
 ```
-It is important that you pick a good user agent. The ideal format is `platform:program:version (by /u/yourname)`, e.g. `macos:roux:v2.0.0 (by /u/beanpup_py)`. This will authticate you as the user given in the username function.
+It is important that you pick a good user agent. The ideal format is `platform:program:version (by /u/yourname)`, e.g. `macos:roux:v2.0.0 (by /u/beanpup_py)`. This will authenticate you as the user given in the username function.
 
 ### Usage
 
@@ -59,12 +59,34 @@ let me = client.unwrap();
 me.submit_link("LINK_TITLE", "LINK", "SUBREDDIT").await?;
 ```
 
-### Read-Only Modules
+### Read-Only Access Without A User
 
-There are also read-only modules that don't need authentication:
+Reddit no longer serves its JSON endpoints to unauthenticated clients, so the read-only
+[Subreddit](https://docs.rs/roux/latest/roux/subreddit/index.html) and
+[User](https://docs.rs/roux/latest/roux/user/index.html) modules need a token too.
+If you don't set a username and password, an application-only token is requested with the
+`client_credentials` grant using just the client id and secret of your Reddit app.
 
-- [Subreddits](https://docs.rs/roux/latest/roux/subreddit/index.html)
-- [Users](https://docs.rs/roux/latest/roux/user/index.html)
+```rust
+use roux::Reddit;
+
+let subreddit = Reddit::new("USER_AGENT", "CLIENT_ID", "CLIENT_SECRET")
+    .subreddit("rust")
+    .await?;
+let hot = subreddit.hot(25, None).await?;
+
+let user = Reddit::new("USER_AGENT", "CLIENT_ID", "CLIENT_SECRET")
+    .user("spez")
+    .await?;
+let overview = user.overview(None).await?;
+
+let subreddits = Reddit::new("USER_AGENT", "CLIENT_ID", "CLIENT_SECRET")
+    .search_subreddits("rust", Some(10), None)
+    .await?;
+```
+
+The unauthenticated constructors `Subreddit::new`, `User::new` and `Subreddits::search` are
+deprecated and will most likely return a 403 from Reddit.
 
 ## Blocking Client
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,35 @@
 //! It is important that you pick a good user agent. The ideal format is
 //! `platform:program:version (by /u/yourname)`, e.g. `macos:roux:v0.3.0 (by /u/beanpup_py)`.
 //!
-//! This will authticate you as the user given in the username function.
+//! This will authenticate you as the user given in the username function.
 //!
+//! ## Read-only access without a user
+//! Reddit no longer serves its JSON endpoints to unauthenticated clients, so
+//! the read-only `Subreddit` and `User` modules also need a token. If you
+//! do not set a username and password, an application-only token is
+//! requested with the `client_credentials` grant using just the client id and
+//! secret of your Reddit app.
+//! ```no_run
+//! use roux::Reddit;
+//! # #[cfg(not(feature = "blocking"))]
+//! # use tokio;
+//!
+//! # #[cfg_attr(not(feature = "blocking"), tokio::main)]
+//! # #[maybe_async::maybe_async]
+//! # async fn main() {
+//! let subreddit = Reddit::new("USER_AGENT", "CLIENT_ID", "CLIENT_SECRET")
+//!     .subreddit("rust")
+//!     .await
+//!     .unwrap();
+//! let hot = subreddit.hot(25, None).await;
+//!
+//! let user = Reddit::new("USER_AGENT", "CLIENT_ID", "CLIENT_SECRET")
+//!     .user("spez")
+//!     .await
+//!     .unwrap();
+//! let overview = user.overview(None).await;
+//! # }
+//! ```
 //!
 //! ## Usage
 //! Using the OAuth client, you can:
@@ -123,28 +150,42 @@ impl Reddit {
         self
     }
 
+    /// Returns `true` when both a username and a password have been set.
+    fn has_user_credentials(&self) -> bool {
+        self.config.username.is_some() && self.config.password.is_some()
+    }
+
+    /// Exchange the configured credentials for an access token.
+    ///
+    /// With `app_only` set to `false` the `password` grant is used, which
+    /// requires a username and password. With `app_only` set to `true` the
+    /// `client_credentials` grant is used, which only needs the client id and
+    /// secret and yields a read-only, user-less token.
     #[maybe_async::maybe_async]
-    async fn create_client(mut self) -> Result<Reddit, util::RouxError> {
+    async fn create_client(mut self, app_only: bool) -> Result<Reddit, util::RouxError> {
         let url = &url::build_url("api/v1/access_token")[..];
-        let form = [
-            ("grant_type", "password"),
-            (
-                "username",
-                &self
-                    .config
-                    .username
-                    .to_owned()
-                    .ok_or(util::RouxError::CredentialsNotSet)?,
-            ),
-            (
-                "password",
-                &self
-                    .config
-                    .password
-                    .to_owned()
-                    .ok_or(util::RouxError::CredentialsNotSet)?,
-            ),
-        ];
+
+        let username;
+        let password;
+        let form: Vec<(&str, &str)> = if app_only {
+            vec![("grant_type", "client_credentials")]
+        } else {
+            username = self
+                .config
+                .username
+                .to_owned()
+                .ok_or(util::RouxError::CredentialsNotSet)?;
+            password = self
+                .config
+                .password
+                .to_owned()
+                .ok_or(util::RouxError::CredentialsNotSet)?;
+            vec![
+                ("grant_type", "password"),
+                ("username", &username),
+                ("password", &password),
+            ]
+        };
 
         let request = self
             .client
@@ -184,16 +225,58 @@ impl Reddit {
     }
 
     /// Login as a user.
+    ///
+    /// This always uses the `password` grant and requires [`Reddit::username`]
+    /// and [`Reddit::password`] to have been set.
     #[maybe_async::maybe_async]
     pub async fn login(self) -> Result<me::Me, util::RouxError> {
-        let reddit = self.create_client().await?;
+        let reddit = self.create_client(false).await?;
         Ok(me::Me::new(&reddit.config, &reddit.client))
     }
 
+    /// Create an authenticated client for read-only access.
+    ///
+    /// If a username and password have been set the `password` grant is used,
+    /// otherwise an application-only token is requested with the
+    /// `client_credentials` grant.
+    #[maybe_async::maybe_async]
+    async fn create_read_client(self) -> Result<Reddit, util::RouxError> {
+        let app_only = !self.has_user_credentials();
+        self.create_client(app_only).await
+    }
+
     /// Create a new authenticated `Subreddit` instance.
+    ///
+    /// Works with or without a username and password; without them an
+    /// application-only token is used.
     #[maybe_async::maybe_async]
     pub async fn subreddit(self, name: &str) -> Result<models::Subreddit, util::RouxError> {
-        let reddit = self.create_client().await?;
+        let reddit = self.create_read_client().await?;
         Ok(models::Subreddit::new_oauth(name, &reddit.client))
+    }
+
+    /// Create a new authenticated `User` instance.
+    ///
+    /// Works with or without a username and password; without them an
+    /// application-only token is used.
+    #[maybe_async::maybe_async]
+    pub async fn user(self, name: &str) -> Result<models::User, util::RouxError> {
+        let reddit = self.create_read_client().await?;
+        Ok(models::User::new_oauth(name, &reddit.client))
+    }
+
+    /// Search subreddits using an authenticated client.
+    ///
+    /// Works with or without a username and password; without them an
+    /// application-only token is used.
+    #[maybe_async::maybe_async]
+    pub async fn search_subreddits(
+        self,
+        name: &str,
+        limit: Option<u32>,
+        options: Option<util::FeedOption>,
+    ) -> Result<models::subreddit::response::SubredditsData, util::RouxError> {
+        let reddit = self.create_read_client().await?;
+        models::Subreddits::search_oauth(name, limit, options, &reddit.client).await
     }
 }

--- a/src/models/subreddit/mod.rs
+++ b/src/models/subreddit/mod.rs
@@ -1,16 +1,24 @@
 //! # Subreddit
 //! A read-only module to read data from a specific subreddit.
 //!
+//! Reddit no longer serves these endpoints to unauthenticated clients, so a
+//! `Subreddit` should be created through
+//! [`Reddit::subreddit`](crate::Reddit::subreddit), which authenticates with
+//! an application-only token when no username and password are set.
+//!
 //! # Basic Usage
 //! ```no_run
-//! use roux::Subreddit;
+//! use roux::Reddit;
 //! # #[cfg(not(feature = "blocking"))]
 //! # use tokio;
 //!
 //! # #[cfg_attr(not(feature = "blocking"), tokio::main)]
 //! # #[maybe_async::maybe_async]
 //! # async fn main() {
-//! let subreddit = Subreddit::new("rust");
+//! let subreddit = Reddit::new("USER_AGENT", "CLIENT_ID", "CLIENT_SECRET")
+//!     .subreddit("rust")
+//!     .await
+//!     .unwrap();
 //! // Now you are able to:
 //!
 //! // Get moderators.
@@ -38,7 +46,7 @@
 //! # Usage with feed options
 //!
 //! ```no_run
-//! use roux::Subreddit;
+//! use roux::Reddit;
 //! use roux::util::{FeedOption, TimePeriod};
 //! # #[cfg(not(feature = "blocking"))]
 //! # use tokio;
@@ -46,7 +54,10 @@
 //! # #[cfg_attr(not(feature = "blocking"), tokio::main)]
 //! # #[maybe_async::maybe_async]
 //! # async fn main() {
-//! let subreddit = Subreddit::new("astolfo");
+//! let subreddit = Reddit::new("USER_AGENT", "CLIENT_ID", "CLIENT_SECRET")
+//!     .subreddit("astolfo")
+//!     .await
+//!     .unwrap();
 //!
 //! // Gets top 10 posts from this month
 //! let options = FeedOption::new().period(TimePeriod::ThisMonth);
@@ -78,14 +89,46 @@ use crate::models::{Comments, Moderators, Submissions};
 pub struct Subreddits;
 
 impl Subreddits {
-    /// Search subreddits
+    /// Search subreddits without authentication.
+    ///
+    /// Reddit blocks unauthenticated requests to this endpoint, so this will
+    /// almost certainly fail with a 403. Use
+    /// [`Reddit::search_subreddits`](crate::Reddit::search_subreddits) or
+    /// [`Subreddits::search_oauth`] instead.
+    #[deprecated(
+        since = "2.3.0",
+        note = "Reddit blocks unauthenticated API access; use `Reddit::search_subreddits` instead"
+    )]
     #[maybe_async::maybe_async]
     pub async fn search(
         name: &str,
         limit: Option<u32>,
         options: Option<FeedOption>,
     ) -> Result<SubredditsData, RouxError> {
-        let url = &mut format!("https://www.reddit.com/subreddits/search.json?q={}", name);
+        let url = format!("https://www.reddit.com/subreddits/search.json?q={}", name);
+        Self::search_with(url, limit, options, &default_client()).await
+    }
+
+    /// Search subreddits using an oauth client from the `Reddit` module.
+    #[maybe_async::maybe_async]
+    pub async fn search_oauth(
+        name: &str,
+        limit: Option<u32>,
+        options: Option<FeedOption>,
+        client: &Client,
+    ) -> Result<SubredditsData, RouxError> {
+        let url = format!("https://oauth.reddit.com/subreddits/search.json?q={}", name);
+        Self::search_with(url, limit, options, client).await
+    }
+
+    #[maybe_async::maybe_async]
+    async fn search_with(
+        mut url: String,
+        limit: Option<u32>,
+        options: Option<FeedOption>,
+        client: &Client,
+    ) -> Result<SubredditsData, RouxError> {
+        let url = &mut url;
 
         if let Some(limit) = limit {
             url.push_str(&format!("&limit={}", limit));
@@ -94,8 +137,6 @@ impl Subreddits {
         if let Some(options) = options {
             options.build_url(url);
         }
-
-        let client = default_client();
 
         Ok(client
             .get(&url.to_owned())
@@ -116,7 +157,15 @@ pub struct Subreddit {
 }
 
 impl Subreddit {
-    /// Create a new `Subreddit` instance.
+    /// Create a new unauthenticated `Subreddit` instance.
+    ///
+    /// Reddit blocks unauthenticated requests to these endpoints, so this
+    /// will almost certainly fail with a 403. Use
+    /// [`Reddit::subreddit`](crate::Reddit::subreddit) instead.
+    #[deprecated(
+        since = "2.3.0",
+        note = "Reddit blocks unauthenticated API access; use `Reddit::subreddit` instead"
+    )]
     pub fn new(name: &str) -> Subreddit {
         let subreddit_url = format!("https://www.reddit.com/r/{}", name);
 
@@ -294,51 +343,5 @@ impl Subreddit {
     ) -> Result<Comments, RouxError> {
         self.get_comment_feed(&format!("comments/{}", article), depth, limit)
             .await
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::Subreddit;
-    use super::Subreddits;
-
-    #[maybe_async::async_impl]
-    #[tokio::test]
-    async fn test_no_auth() {
-        let subreddit = Subreddit::new("astolfo");
-
-        // Test feeds
-        let hot = subreddit.hot(25, None).await;
-        assert!(hot.is_ok());
-
-        let rising = subreddit.rising(25, None).await;
-        assert!(rising.is_ok());
-
-        let top = subreddit.top(25, None).await;
-        assert!(top.is_ok());
-
-        let latest_comments = subreddit.latest_comments(None, Some(25)).await;
-        assert!(latest_comments.is_ok());
-
-        let article_id = &hot.unwrap().data.children.first().unwrap().data.id.clone();
-        let article_comments = subreddit.article_comments(article_id, None, Some(25)).await;
-        assert!(article_comments.is_ok());
-
-        // Test subreddit data.
-        let data_res = subreddit.about().await;
-        assert!(data_res.is_ok());
-
-        let data = data_res.unwrap();
-        assert!(data.title == Some(String::from("Rider of Black, Astolfo")));
-        assert!(data.subscribers.is_some());
-        assert!(data.subscribers.unwrap() > 1000);
-
-        assert!(subreddit.moderators().await.is_err());
-
-        // Test subreddit search
-        let subreddits_limit = 3u32;
-        let subreddits = Subreddits::search("rust", Some(subreddits_limit), None).await;
-        assert!(subreddits.is_ok());
-        assert!(subreddits.unwrap().data.children.len() == subreddits_limit as usize);
     }
 }

--- a/src/models/user/mod.rs
+++ b/src/models/user/mod.rs
@@ -1,9 +1,14 @@
 //! # User
 //! A read-only module to read data from for a specific user.
 //!
+//! Reddit no longer serves these endpoints to unauthenticated clients, so a
+//! `User` should be created through [`Reddit::user`](crate::Reddit::user),
+//! which authenticates with an application-only token when no username and
+//! password are set.
+//!
 //! # Usage
 //! ```no_run
-//! use roux::User;
+//! use roux::Reddit;
 //! use roux::util::FeedOption;
 //! # #[cfg(not(feature = "blocking"))]
 //! # use tokio;
@@ -11,7 +16,10 @@
 //! # #[cfg_attr(not(feature = "blocking"), tokio::main)]
 //! # #[maybe_async::maybe_async]
 //! # async fn main() {
-//! let user = User::new("kasuporo");
+//! let user = Reddit::new("USER_AGENT", "CLIENT_ID", "CLIENT_SECRET")
+//!     .user("kasuporo")
+//!     .await
+//!     .unwrap();
 //! // Now you are able to:
 //!
 //! // Get overview
@@ -37,22 +45,42 @@ use crate::models::{About, Comments, Overview, Submissions};
 pub struct User {
     /// User's name.
     pub user: String,
+    url: String,
     client: Client,
 }
 
 impl User {
-    /// Create a new `User` instance.
+    /// Create a new unauthenticated `User` instance.
+    ///
+    /// Reddit blocks unauthenticated requests to these endpoints, so this
+    /// will almost certainly fail with a 403. Use
+    /// [`Reddit::user`](crate::Reddit::user) instead.
+    #[deprecated(
+        since = "2.3.0",
+        note = "Reddit blocks unauthenticated API access; use `Reddit::user` instead"
+    )]
     pub fn new(user: &str) -> User {
         User {
             user: user.to_owned(),
+            url: format!("https://www.reddit.com/user/{}", user),
             client: default_client(),
+        }
+    }
+
+    /// Create a new authenticated `User` instance using an oauth client
+    /// from the `Reddit` module.
+    pub fn new_oauth(user: &str, client: &Client) -> User {
+        User {
+            user: user.to_owned(),
+            url: format!("https://oauth.reddit.com/user/{}", user),
+            client: client.to_owned(),
         }
     }
 
     /// Get user's overview.
     #[maybe_async::maybe_async]
     pub async fn overview(&self, options: Option<FeedOption>) -> Result<Overview, RouxError> {
-        let url = &mut format!("https://www.reddit.com/user/{}/overview/.json?", self.user);
+        let url = &mut format!("{}/overview/.json?", self.url);
 
         if let Some(options) = options {
             options.build_url(url);
@@ -70,7 +98,7 @@ impl User {
     /// Get user's submitted posts.
     #[maybe_async::maybe_async]
     pub async fn submitted(&self, options: Option<FeedOption>) -> Result<Submissions, RouxError> {
-        let url = &mut format!("https://www.reddit.com/user/{}/submitted/.json?", self.user);
+        let url = &mut format!("{}/submitted/.json?", self.url);
 
         if let Some(options) = options {
             options.build_url(url);
@@ -88,7 +116,7 @@ impl User {
     /// Get user's submitted comments.
     #[maybe_async::maybe_async]
     pub async fn comments(&self, options: Option<FeedOption>) -> Result<Comments, RouxError> {
-        let url = &mut format!("https://www.reddit.com/user/{}/comments/.json?", self.user);
+        let url = &mut format!("{}/comments/.json?", self.url);
 
         if let Some(options) = options {
             options.build_url(url);
@@ -106,7 +134,7 @@ impl User {
     /// Get user's about page
     #[maybe_async::maybe_async]
     pub async fn about(&self, options: Option<FeedOption>) -> Result<About, RouxError> {
-        let url = &mut format!("https://www.reddit.com/user/{}/about/.json?", self.user);
+        let url = &mut format!("{}/about/.json?", self.url);
 
         if let Some(options) = options {
             options.build_url(url);
@@ -119,39 +147,5 @@ impl User {
             .await?
             .json::<About>()
             .await?)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::User;
-    use crate::util::FeedOption;
-
-    #[maybe_async::async_impl]
-    #[tokio::test]
-    async fn test_no_auth() {
-        let user = User::new("beneater");
-
-        // Test overview
-        let overview = user.overview(None).await;
-        assert!(overview.is_ok());
-
-        // Test submitted
-        let submitted = user.submitted(None).await;
-        assert!(submitted.is_ok());
-
-        // Test comments
-        let comments = user.comments(None).await;
-        assert!(comments.is_ok());
-
-        // Test about
-        let about = user.about(None).await;
-        assert!(about.is_ok());
-
-        // Test feed options
-        let after = comments.unwrap().data.after.unwrap();
-        let after_options = FeedOption::new().after(&after);
-        let next_comments = user.comments(Some(after_options)).await;
-        assert!(next_comments.is_ok());
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -71,6 +71,59 @@ mod tests {
         assert!(new_client.moderators().await.is_ok());
     }
 
+    #[maybe_async::async_impl]
+    #[tokio::test]
+    async fn test_app_only() {
+        dotenv::dotenv().ok();
+
+        let client_id = env::var("CLIENT_ID").unwrap();
+        let client_secret = env::var("CLIENT_SECRET").unwrap();
+
+        // No username or password: the client_credentials grant is used.
+        let subreddit = Reddit::new(&USER_AGENT, &client_id, &client_secret)
+            .subreddit("rust")
+            .await
+            .unwrap();
+
+        let hot = subreddit.hot(5, None).await.unwrap();
+        assert_eq!(hot.data.children.len(), 5);
+        assert!(subreddit.about().await.is_ok());
+        assert!(subreddit.latest_comments(None, Some(5)).await.is_ok());
+
+        let article_id = hot.data.children.first().unwrap().data.id.clone();
+        assert!(subreddit
+            .article_comments(&article_id, None, Some(5))
+            .await
+            .is_ok());
+
+        let user = Reddit::new(&USER_AGENT, &client_id, &client_secret)
+            .user("spez")
+            .await
+            .unwrap();
+
+        assert!(user.about(None).await.is_ok());
+        let comments = user
+            .comments(Some(FeedOption::new().limit(5)))
+            .await
+            .unwrap();
+        assert!(!comments.data.children.is_empty());
+
+        let subreddits = Reddit::new(&USER_AGENT, &client_id, &client_secret)
+            .search_subreddits("rust", Some(3), None)
+            .await
+            .unwrap();
+        assert_eq!(subreddits.data.children.len(), 3);
+
+        // login() must keep requiring user credentials.
+        let login = Reddit::new(&USER_AGENT, &client_id, &client_secret)
+            .login()
+            .await;
+        assert!(matches!(
+            login,
+            Err(roux::util::RouxError::CredentialsNotSet)
+        ));
+    }
+
     #[allow(dead_code)]
     #[maybe_async::sync_impl]
     fn test_oauth() {
@@ -120,5 +173,49 @@ mod tests {
 
         assert!(new_client.top(10, None).is_ok());
         assert!(new_client.moderators().is_ok());
+    }
+
+    #[maybe_async::sync_impl]
+    #[test]
+    fn test_app_only() {
+        dotenv::dotenv().ok();
+
+        let client_id = env::var("CLIENT_ID").unwrap();
+        let client_secret = env::var("CLIENT_SECRET").unwrap();
+
+        // No username or password: the client_credentials grant is used.
+        let subreddit = Reddit::new(&USER_AGENT, &client_id, &client_secret)
+            .subreddit("rust")
+            .unwrap();
+
+        let hot = subreddit.hot(5, None).unwrap();
+        assert_eq!(hot.data.children.len(), 5);
+        assert!(subreddit.about().is_ok());
+        assert!(subreddit.latest_comments(None, Some(5)).is_ok());
+
+        let article_id = hot.data.children.first().unwrap().data.id.clone();
+        assert!(subreddit
+            .article_comments(&article_id, None, Some(5))
+            .is_ok());
+
+        let user = Reddit::new(&USER_AGENT, &client_id, &client_secret)
+            .user("spez")
+            .unwrap();
+
+        assert!(user.about(None).is_ok());
+        let comments = user.comments(Some(FeedOption::new().limit(5))).unwrap();
+        assert!(!comments.data.children.is_empty());
+
+        let subreddits = Reddit::new(&USER_AGENT, &client_id, &client_secret)
+            .search_subreddits("rust", Some(3), None)
+            .unwrap();
+        assert_eq!(subreddits.data.children.len(), 3);
+
+        // login() must keep requiring user credentials.
+        let login = Reddit::new(&USER_AGENT, &client_id, &client_secret).login();
+        assert!(matches!(
+            login,
+            Err(roux::util::RouxError::CredentialsNotSet)
+        ));
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -17,6 +17,14 @@ mod tests {
     #[allow(dead_code)]
     static USER_AGENT: &str = "macos:roux:v1.4.0 (by /u/beanpup_py)";
 
+    /// Returns the app credentials, or `None` if either is missing or empty.
+    #[allow(dead_code)]
+    fn app_credentials() -> Option<(String, String)> {
+        let client_id = env::var("CLIENT_ID").ok().filter(|v| !v.is_empty())?;
+        let client_secret = env::var("CLIENT_SECRET").ok().filter(|v| !v.is_empty())?;
+        Some((client_id, client_secret))
+    }
+
     #[maybe_async::async_impl]
     #[tokio::test]
     async fn test_oauth() {
@@ -76,8 +84,12 @@ mod tests {
     async fn test_app_only() {
         dotenv::dotenv().ok();
 
-        let client_id = env::var("CLIENT_ID").unwrap();
-        let client_secret = env::var("CLIENT_SECRET").unwrap();
+        // Secrets are absent on forks and dependabot PRs, where GitHub sets
+        // them to empty strings, so skip rather than fail there.
+        let Some((client_id, client_secret)) = app_credentials() else {
+            eprintln!("skipping test_app_only: CLIENT_ID and CLIENT_SECRET not set");
+            return;
+        };
 
         // No username or password: the client_credentials grant is used.
         let subreddit = Reddit::new(&USER_AGENT, &client_id, &client_secret)
@@ -180,8 +192,12 @@ mod tests {
     fn test_app_only() {
         dotenv::dotenv().ok();
 
-        let client_id = env::var("CLIENT_ID").unwrap();
-        let client_secret = env::var("CLIENT_SECRET").unwrap();
+        // Secrets are absent on forks and dependabot PRs, where GitHub sets
+        // them to empty strings, so skip rather than fail there.
+        let Some((client_id, client_secret)) = app_credentials() else {
+            eprintln!("skipping test_app_only: CLIENT_ID and CLIENT_SECRET not set");
+            return;
+        };
 
         // No username or password: the client_credentials grant is used.
         let subreddit = Reddit::new(&USER_AGENT, &client_id, &client_secret)


### PR DESCRIPTION
Follow-up to #105 and #104.

Reddit now blocks every unauthenticated `www.reddit.com/*.json` endpoint the read-only modules use (verified: all eleven return a 403 "blocked by network security" page regardless of user agent). This routes them through `oauth.reddit.com` with an application-only token.

- `Reddit::subreddit`, plus new `Reddit::user` and `Reddit::search_subreddits`, request a `client_credentials` token when no username and password are set. With user credentials set they keep using the password grant. `login()` is unchanged and still requires a username and password.
- `User::new_oauth` and `Subreddits::search_oauth` added, mirroring the existing `Subreddit::new_oauth`.
- `Subreddit::new`, `User::new` and `Subreddits::search` are deprecated with a pointer to the replacements.
- Removed the in-crate `test_no_auth` unit tests that hit the dead endpoints. Added an app-only integration test that only needs `CLIENT_ID` and `CLIENT_SECRET`, and marked its blocking variant as a real `#[test]` so the CI job actually runs it. Note the existing blocking `test_oauth` has no `#[test]` attribute and has never run in CI.
- README and module docs updated.

No breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FF8yrayv6XPDMiiUtZTL7o
